### PR TITLE
Fix library.properties to work with spec.

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=SparkFun Bio Sensor Hub Library
 version=1.0.4
-author=Elias Santistevan
+author=Elias Santistevan <techsupport@sparkfun.com>
 maintainer=SparkFun Electronics <sparkfun.com>
 sentence=Library for the MAX32664 Bio Metric Hub IC
 paragraph=The SparkFun Bio Sensor Hub Library is tailored to Maxim Integrated's MAX32664 Bio Sensor Hub interacting with the MAX30101 on [SparkFun's Pulse Oximeter and Heart Rate Monitor](https://www.sparkfun.com/products/15219). The Bio Sensor Hub is a practically microscopic cortex-m0 micro-controller that handles the algorithmic calculation of  the light data gathered by the MAX30101 Pulse Oximeter and Heart Rate Monitor, to produce accurate and fast blood oxygen and heart rate readings. The library provides simple function calls to all available commands on the chip as well as example code demonstrating  basic to advanced capabilities of the chip.
 category=Sensors
-url="https://github.com/sparkfun/SparkFun_Bio_Sensor_Hub_Library"
+url=https://github.com/sparkfun/SparkFun_Bio_Sensor_Hub_Library
 architecture=*


### PR DESCRIPTION
`library.properties` has some issues that prevent it from being properly parsed.

 - url field must not have quotes, fixed
 - I've added an email to the author field that I've seen used on other SparkFun Arduino projects, please feel free to change if desired.