### PR TITLE
v1.0.6 : allow pins to be defined at begin instead of at class instantiation

### DIFF
--- a/examples/Example1_config_BPM_Mode1/Example1_config_BPM_Mode1.ino
+++ b/examples/Example1_config_BPM_Mode1/Example1_config_BPM_Mode1.ino
@@ -58,7 +58,7 @@ void setup(){
   if (result == 0) // Zero errors!
     Serial.println("Sensor started!");
   else
-    Serial.println("Could not communicate with the sensor!!!");
+    Serial.println("Could not communicate with the sensor!");
  
   Serial.println("Configuring Sensor...."); 
   int error = bioHub.configBpm(MODE_ONE); // Configuring just the BPM settings. 

--- a/examples/Example2_config_BPM_Mode2/Example2_config_BPM_Mode2.ino
+++ b/examples/Example2_config_BPM_Mode2/Example2_config_BPM_Mode2.ino
@@ -62,7 +62,7 @@ void setup(){
   if (result == 0) //Zero errors!
     Serial.println("Sensor started!");
   else
-    Serial.println("Could not communicate with the sensor!!!");
+    Serial.println("Could not communicate with the sensor!");
  
   Serial.println("Configuring Sensor...."); 
   int error = bioHub.configBpm(MODE_TWO); // Configuring just the BPM settings. 

--- a/examples/Example5_define_pins_at_begin/Example5_define_pins_at_begin.ino
+++ b/examples/Example5_define_pins_at_begin/Example5_define_pins_at_begin.ino
@@ -63,7 +63,7 @@ void setup(){
   if (result == 0) // Zero errors!
     Serial.println("Sensor started!");
   else
-    Serial.println("Could not communicate with the sensor!!!");
+    Serial.println("Could not communicate with the sensor!");
  
   Serial.println("Configuring Sensor...."); 
   int error = bioHub.configBpm(MODE_ONE); // Configuring just the BPM settings. 

--- a/examples/Example5_define_pins_at_begin/Example5_define_pins_at_begin.ino
+++ b/examples/Example5_define_pins_at_begin/Example5_define_pins_at_begin.ino
@@ -1,0 +1,103 @@
+/*
+ This example sketch gives you exactly what the SparkFun Pulse Oximiter and
+ Heart Rate Monitor is designed to do: read heart rate and blood oxygen levels.
+ 
+ Here the reset and mfio pins are defined at begin, instead of when the
+ SparkFun_Bio_Sensor_Hub is instantiated. This makes it much easier to
+ instantiate the class using a factory method.
+ 
+ This board requires I-squared-C connections but also connections to the reset
+ and mfio pins. When using the device keep LIGHT and CONSISTENT pressure on the
+ sensor. Otherwise you may crush the capillaries in your finger which results
+ in bad or no results. A summary of the hardware connections are as follows: 
+ SDA -> SDA
+ SCL -> SCL
+ RESET -> PIN 4
+ MFIO -> PIN 5
+
+ Author: Elias Santistevan
+ Date: 8/2019
+ SparkFun Electronics
+
+ If you run into an error code check the following table to help diagnose your
+ problem: 
+ 1 = Unavailable Command
+ 2 = Unavailable Function
+ 3 = Data Format Error
+ 4 = Input Value Error
+ 5 = Try Again
+ 255 = Error Unknown
+*/
+
+#include <SparkFun_Bio_Sensor_Hub_Library.h>
+#include <Wire.h>
+
+// Reset pin, MFIO pin
+int resPin = 4;
+int mfioPin = 5;
+
+// The reset pin and MFIO pin will be defined at begin in this example.
+SparkFun_Bio_Sensor_Hub bioHub; 
+
+bioData body;  
+// ^^^^^^^^^
+// What's this!? This is a type (like int, byte, long) unique to the SparkFun
+// Pulse Oximeter and Heart Rate Monitor. Unlike those other types it holds
+// specific information on your heartrate and blood oxygen levels. BioData is
+// actually a specific kind of type, known as a "struct". 
+// You can choose another variable name other than "body", like "blood", or
+// "readings", but I chose "body". Using this "body" varible in the 
+// following way gives us access to the following data: 
+// body.heartrate  - Heartrate
+// body.confidence - Confidence in the heartrate value
+// body.oxygen     - Blood oxygen level
+// body.status     - Has a finger been sensed?
+
+
+void setup(){
+
+  Serial.begin(115200);
+
+  Wire.begin();
+  int result = bioHub.begin(Wire, resPin, mfioPin); // Define the pins here
+  if (result == 0) // Zero errors!
+    Serial.println("Sensor started!");
+  else
+    Serial.println("Could not communicate with the sensor!!!");
+ 
+  Serial.println("Configuring Sensor...."); 
+  int error = bioHub.configBpm(MODE_ONE); // Configuring just the BPM settings. 
+  if(error == 0){ // Zero errors!
+    Serial.println("Sensor configured.");
+  }
+  else {
+    Serial.println("Error configuring sensor.");
+    Serial.print("Error: "); 
+    Serial.println(error); 
+  }
+
+  // Data lags a bit behind the sensor, if you're finger is on the sensor when
+  // it's being configured this delay will give some time for the data to catch
+  // up. 
+  Serial.println("Loading up the buffer with data....");
+  delay(4000); 
+  
+}
+
+void loop(){
+
+    // Information from the readBpm function will be saved to our "body"
+    // variable.  
+    body = bioHub.readBpm();
+    Serial.print("Heartrate: ");
+    Serial.println(body.heartRate); 
+    Serial.print("Confidence: ");
+    Serial.println(body.confidence); 
+    Serial.print("Oxygen: ");
+    Serial.println(body.oxygen); 
+    Serial.print("Status: ");
+    Serial.println(body.status); 
+    // Slow it down or your heart rate will go up trying to keep up
+    // with the flow of numbers
+    delay(250); 
+}

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SparkFun Bio Sensor Hub Library
-version=1.0.5
+version=1.0.6
 author=Elias Santistevan <techsupport@sparkfun.com>
 maintainer=SparkFun Electronics <sparkfun.com>
 sentence=Library for the MAX32664 Bio Metric Hub IC

--- a/src/SparkFun_Bio_Sensor_Hub_Library.cpp
+++ b/src/SparkFun_Bio_Sensor_Hub_Library.cpp
@@ -20,13 +20,17 @@ kk
 
 #include "SparkFun_Bio_Sensor_Hub_Library.h"
 
-SparkFun_Bio_Sensor_Hub::SparkFun_Bio_Sensor_Hub(uint16_t resetPin, uint16_t mfioPin, uint8_t address) {
+SparkFun_Bio_Sensor_Hub::SparkFun_Bio_Sensor_Hub(int resetPin, int mfioPin, uint8_t address) {
 
   _resetPin = resetPin;
+  if (resetPin >= 0)
+    pinMode(_resetPin, OUTPUT); // Set the pin as output
+
   _mfioPin = mfioPin;
+  if (mfioPin >= 0)
+    pinMode(_mfioPin, OUTPUT); // Set the pin as output
+
   _address = address;
-  pinMode(_mfioPin, OUTPUT);
-  pinMode(_resetPin, OUTPUT); // Set these pins as output
 
 }
 
@@ -37,11 +41,26 @@ SparkFun_Bio_Sensor_Hub::SparkFun_Bio_Sensor_Hub(uint16_t resetPin, uint16_t mfi
 // in application mode and will return two bytes, the first 0x00 is a
 // successful communcation byte, followed by 0x00 which is the byte indicating
 // which mode the IC is in.
-uint8_t SparkFun_Bio_Sensor_Hub::begin( TwoWire &wirePort ) {
+uint8_t SparkFun_Bio_Sensor_Hub::begin( TwoWire &wirePort, int resetPin, int mfioPin ) {
 
   _i2cPort = &wirePort;
   //  _i2cPort->begin(); A call to Wire.begin should occur in sketch
   //  to avoid multiple begins with other sketches.
+
+  if (resetPin >= 0)
+  {
+    _resetPin = resetPin;
+    pinMode(_resetPin, OUTPUT); // Set the pin as output
+  }
+
+  if (mfioPin >= 0)
+  {
+    _mfioPin = mfioPin;
+    pinMode(_mfioPin, OUTPUT); // Set the pin as output
+  }
+
+  if ((_resetPin < 0) || (_mfioPin < 0)) // Bail if the pins have still not been defined
+    return 0xFF; // Return ERR_UNKNOWN
 
   digitalWrite(_mfioPin, HIGH);
   digitalWrite(_resetPin, LOW);
@@ -61,11 +80,26 @@ uint8_t SparkFun_Bio_Sensor_Hub::begin( TwoWire &wirePort ) {
 // in bootloader mode and will return two bytes, the first 0x00 is a
 // successful communcation byte, followed by 0x08 which is the byte indicating
 // that the board is in bootloader mode.
-uint8_t SparkFun_Bio_Sensor_Hub::beginBootloader( TwoWire &wirePort ) {
+uint8_t SparkFun_Bio_Sensor_Hub::beginBootloader( TwoWire &wirePort, int resetPin, int mfioPin ) {
 
   _i2cPort = &wirePort;
   //  _i2cPort->begin(); A call to Wire.begin should occur in sketch
   //  to avoid multiple begins with other sketches.
+
+  if (resetPin >= 0)
+  {
+    _resetPin = resetPin;
+    pinMode(_resetPin, OUTPUT); // Set the pin as output
+  }
+
+  if (mfioPin >= 0)
+  {
+    _mfioPin = mfioPin;
+    pinMode(_mfioPin, OUTPUT); // Set the pin as output
+  }
+
+  if ((_resetPin < 0) || (_mfioPin < 0)) // Bail if the pins have still not been defined
+    return 0xFF; // Return ERR_UNKNOWN
 
   digitalWrite(_mfioPin, LOW);
   digitalWrite(_resetPin, LOW);

--- a/src/SparkFun_Bio_Sensor_Hub_Library.h
+++ b/src/SparkFun_Bio_Sensor_Hub_Library.h
@@ -314,7 +314,7 @@ class SparkFun_Bio_Sensor_Hub
     uint8_t bpmSenArrTwo[MAXFAST_ARRAY_SIZE + MAXFAST_EXTENDED_DATA + MAX30101_LED_ARRAY] {};
 
     // Constructor ----------
-    SparkFun_Bio_Sensor_Hub(uint16_t, uint16_t, uint8_t address = 0x55);
+    SparkFun_Bio_Sensor_Hub(int resetPin = -1, int mfioPin = -1, uint8_t address = 0x55);
 
     // Functions ------------
 
@@ -325,7 +325,7 @@ class SparkFun_Bio_Sensor_Hub
     // in application mode and will return two bytes, the first 0x00 is a
     // successful communcation byte, followed by 0x00 which is the byte indicating
     // which mode the IC is in.
-    uint8_t begin( TwoWire &wirePort = Wire);
+    uint8_t begin( TwoWire &wirePort = Wire, int resetPin = -1, int mfioPin = -1 );
 
     // Family Byte: READ_DEVICE_MODE (0x02) Index Byte: 0x00, Write Byte: 0x00
     // The following function puts the MAX32664 into bootloader mode. To place the MAX32664 into
@@ -334,7 +334,7 @@ class SparkFun_Bio_Sensor_Hub
     // in bootloader mode and will return two bytes, the first 0x00 is a
     // successful communcation byte, followed by 0x08 which is the byte indicating
     // that the board is in bootloader mode.
-    uint8_t beginBootloader( TwoWire &wirePort = Wire);
+    uint8_t beginBootloader( TwoWire &wirePort = Wire, int resetPin = -1, int mfioPin = -1 );
 
     // Family Byte: HUB_STATUS (0x00), Index Byte: 0x00, No Write Byte.
     // The following function checks the status of the FIFO.
@@ -674,8 +674,8 @@ class SparkFun_Bio_Sensor_Hub
   private:
 
     // Variables -----------
-    uint8_t _resetPin;
-    uint8_t _mfioPin;
+    int _resetPin;
+    int _mfioPin;
     uint8_t _address;
     uint32_t _writeCoefArr[3] {};
     uint8_t _userSelectedMode;


### PR DESCRIPTION
Hi @edspark ,

I'd like to add the Bio Sensor Hub to the new framework. Trouble is, having to specify the reset and mfio pins when you instantiate the class causes problems... This PR allows the pins to be defined at begin instead. Everything is backward-compatible though. I've created a new example showing how to pass the pins to ```begin```.

Please give it a review and merge if you are happy.

Thanks!
Paul